### PR TITLE
Add option for specifying electron-prebuilt path

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,7 +25,7 @@ const argv = require('yargs')
   .epilog('Copyright 2015')
   .argv;
 
-if (!argv.e){
+if (!argv.e) {
   argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt')
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,7 +26,7 @@ const argv = require('yargs')
   .argv;
 
 if (!argv.e) {
-  argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt')
+  argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt');
 }
 
 if (!argv.v) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,7 +60,7 @@ if (!argv.n) {
 }
 
 if (!argv.m) {
-  // NB: We assume here that we're going to rebuild the immediate parent's 
+  // NB: We assume here that we're going to rebuild the immediate parent's
   // node modules, which might not always be the case but it's at least a
   // good guess
   try {
@@ -83,7 +83,7 @@ if (!electronPath && !nodeModuleVersion) {
 shouldRebuildPromise
   .then(x => {
     if (!x) process.exit(0);
-    
+
     return installNodeHeaders(argv.v, null, null, argv.a)
       .then(() => rebuildNativeModules(argv.v, argv.m, null, argv.a))
       .then(() => process.exit(0));

--- a/src/cli.js
+++ b/src/cli.js
@@ -47,7 +47,6 @@ if (!argv.v) {
 let electronPath = null;
 let nodeModuleVersion = null;
 
-console.log(argv.e);
 if (!argv.n) {
   try {
     let pathDotText = path.join(argv.e, 'path.txt');

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,20 +20,23 @@ const argv = require('yargs')
   .alias('a', 'arch')
   .describe('m', 'The path to the node_modules directory to rebuild')
   .alias('m', 'module-dir')
+  .describe('e', 'The path to electron-prebuilt')
+  .alias('e', 'electron-prebuilt-dir')
   .epilog('Copyright 2015')
   .argv;
-  
+
+if (!argv.e){
+  argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt')
+}
+
 if (!argv.v) {
   // NB: We assume here that electron-prebuilt is a sibling package of ours
   let pkg = null;
   try {
-    let pkgJson = path.join(
-      __dirname,
-      '..', '..', 'electron-prebuilt',
-      'package.json');
-      
+    let pkgJson = path.join(argv.e, 'package.json');
+
     pkg = require(pkgJson);
-      
+
     argv.v = pkg.version;
   } catch (e) {
     console.error("Unable to find electron-prebuilt's version number, either install it or specify an explicit version");
@@ -44,13 +47,10 @@ if (!argv.v) {
 let electronPath = null;
 let nodeModuleVersion = null;
 
+console.log(argv.e);
 if (!argv.n) {
   try {
-    let pathDotText = path.join(
-      __dirname,
-      '..', '..', 'electron-prebuilt',
-      'path.txt');
-          
+    let pathDotText = path.join(argv.e, 'path.txt');
     electronPath = fs.readFileSync(pathDotText, 'utf8');
   } catch (e) {
     console.error("Couldn't find electron-prebuilt and no --node-module-version parameter set, always rebuilding");


### PR DESCRIPTION
This will allow an electron-cli module to use the electron that is specified by the app.